### PR TITLE
Procedure for preparing for and running nosetests.

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,178 @@
+# Running unit tests tests on ViderumGlobal/ckan-cloud-docker
+
+## Purpose of this document
+
+This document details the procedure to be followed when running unit tests on ViderumGlobal/ckan-cloud-docker using nosetests
+
+## Related links
+
+* [ViderumGlobal/ckan-cloud-docker GitHub repository](https://github.com/ViderumGlobal/ckan-cloud-docker)
+* [Contributing guide: Testing CKAN](https://docs.ckan.org/en/2.8/contributing/test.html) - about back-end tests and Front-end tests
+* [Extending guide: Testing extensions](https://docs.ckan.org/en/2.8/extensions/testing-extensions.html)
+* [Contributing guide: Testing coding standards](https://docs.ckan.org/en/2.8/contributing/testing.html)
+
+## Bring up the CKAN stack instance
+
+The following instructions deviate a bit from the instructions for bringing up a CKAN instance on your PC. Refer also to the installation instructions in the [ViderumGlobal/ckan-cloud-docker repository](https://github.com/ViderumGlobal/ckan-cloud-docker).
+
+First, cd to the directory containing your `docker-compose.yaml`, `.docker-compose-db.yaml` and `.docker-compose.datagov-theme.yaml` files.
+
+```
+$ cd ckan-cloud-docker
+```
+
+(optional) Eensure a fresh start with up-to-date images:
+
+
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      down -v
+```
+Then remove images and volumes (only if you are paranoid).
+
+Start the CKAN instance
+
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      up -d nginx
+
+```
+
+Wait several seconds until the instance stabilizes. You may monitor its initialization process using:
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      logs -f
+```
+
+The wait ends when
+```
+$ curl http://nginx:8080/api/3
+```
+responds successfully.
+
+An unsuccessful response would be HTTP 502 (Bad Gateway). A successful response would be `{"version": 3}` not having newline at end.
+
+Once you see a successful response, create a CKAN admin user:
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+	  exec ckan ckan-paster --plugin=ckan \
+      sysadmin add -c /etc/ckan/production.ini admin password=12345678 email=admin@localhost
+```
+
+You should see the following prompt:
+```
+User "admin" not found
+Create new user: admin? [y/n]
+```
+Enter y and now you should see:
+```
+Creating user: 'admin'
+{...
+.
+.
+.
+...}
+Added admin as sysadmin
+```
+
+
+Now, if you want to, you can login to [http://nginx:8080](http://nginx:8080) with username `admin` and password `12345678`.
+
+The following instructions are based upon [Testing CKAN - Back-end tests](https://docs.ckan.org/en/2.8/contributing/test.html#back-end-tests).
+
+The first step is to start a shell inside the `ckan` service (implemented by the `ckan-cloud-docker_ckan_1` container).
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      exec ckan /bin/bash
+```
+
+The following commands are executed inside the container.
+First, install development requirements.
+
+```
+$ . venv/bin/activate
+$ ckan-pip install  -r venv/src/ckan/dev-requirements.txt
+```
+Verify that `nose` is installed by trying to import it:
+```
+$ python
+Python 2.7.9 (default, Sep 25 2018, 20:42:16) 
+[GCC 4.9.2] on linux2
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import nose
+>>> exit(0)
+```
+
+Exit the shell and the container.
+```
+$ exit
+```
+
+Now prepare the datastore DB for unit tests as follows.
+
+Start `psql` inside the `datastore-db` service (the `ckan-cloud-docker_datastore-db_1` container).
+
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      exec --user postgres datastore-db psql
+```
+
+Enter the following commands.
+
+```
+postgres=# CREATE ROLE ckan_default WITH LOGIN PASSWORD 'pass';
+postgres=# CREATE ROLE datastore_default WITH LOGIN PASSWORD 'pass';
+postgres-# \q
+```
+The last command closes psql and you are back in your host computer's shell. Now create the test databases:
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      exec --user postgres datastore-db createdb -O ckan_default ckan_test -E utf-8 -T template0
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      exec --user postgres datastore-db createdb -O ckan_default datastore_test -E utf-8 -T template0
+```
+
+The `-T template0` option is needed to fix a data encoding incompatibility in recent versions of PostgreSQL.
+
+Copy `test-core.ini` (currently available in this repository as `TESTING.test-core.ini`) into the `ckan` service:
+```
+docker cp TESTING.test-core.ini ckan-cloud-docker_ckan_1:/usr/lib/ckan/venv/src/ckan/test-core.ini
+```
+Now we have to run a script in the `ckan` service and pipe its output into the `datastore-db` instance.
+```
+$ docker-compose -f docker-compose.yaml -f .docker-compose-db.yaml -f .docker-compose.datagov-theme.yaml \
+      exec ckan /bin/bash
+```
+Inside the `ckan` service, execute:
+```
+$ . venv/bin/activate
+$ cd /usr/lib/ckan/venv/src/ckan
+$ export PGPASSWORD=123456
+$ paster datastore set-permissions -c test-core.ini | psql -h datastore-db -U postgres
+```
+
+Solr is already configured as 'multi-core'. To verify it, you may run the following command inside the `ckan` container:
+```
+$ grep solr_url /etc/ckan/production.ini
+# Possible outputs:
+# single-core: solr_url = http://solr:8983/solr
+# multi-core:  solr_url = http://solr:8983/solr/ckan
+```
+
+Finally, run the unit tests inside the `ckan` container:
+```
+$ . venv/bin/activate
+$ nosetests --ckan --with-pylons=/usr/lib/ckan/venv/src/ckan/test-core.ini ckan ckanext
+```
+
+## CURRENT STATUS
+
+As of May 1, 2019:
+
+Ran 2298 tests in 2508.135 seconds.
+* Skipped: 3 tests.
+* Errors: 67 tests.
+* Failures: 14 tests.
+
+Some of the reasons for failure of tests are:
+* Several test errors were due to 'http://nginx:8080' != 'http://test.ckan.net' (ckan.site_url).

--- a/TESTING.test-core.ini
+++ b/TESTING.test-core.ini
@@ -1,0 +1,284 @@
+#
+# ckan - Pylons testing environment configuration for running unit tests on ViderumGlobal/ckan-cloud-docker
+#
+[DEFAULT]
+debug = false
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/%(ckan.site_id)s/
+testing = true
+beaker.session.key = ckan
+
+beaker.session.secret = This_is_a_secret_or_is_it
+app_instance_uuid = 7dcd357a-857f-4ab0-845f-9ccd85f98cb8
+
+# repoze.who config
+who.config_file = %(here)s/who.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who_log.ini
+# Session timeout (user logged out after period of inactivity, in seconds).
+# Inactive by default, so the session doesn't expire.
+# who.timeout = 86400
+
+## Database Settings
+sqlalchemy.url = postgresql://ckan_default:pass@datastore-db/ckan_test
+
+## Datastore
+ckan.datastore.write_url = postgresql://ckan_default:pass@datastore-db/datastore_test
+ckan.datastore.read_url = postgresql://datastore_default:pass@datastore-db/datastore_test
+
+# PostgreSQL' full-text search parameters
+ckan.datastore.default_fts_lang = english
+ckan.datastore.default_fts_index_method = gist
+
+
+# Site settings
+ckan.site_url = http://nginx:8080
+#ckan.use_pylons_response_cleanup_middleware = true
+
+## Authorization Settings
+
+ckan.auth.anon_create_dataset = false
+ckan.auth.create_unowned_dataset=true
+ckan.auth.create_dataset_if_not_in_organization = true
+ckan.auth.user_create_groups = true
+ckan.auth.user_create_organizations = true
+ckan.auth.user_delete_groups=true
+ckan.auth.user_delete_organizations=true
+ckan.auth.create_user_via_api = false
+ckan.auth.create_user_via_web = true
+#ckan.auth.roles_that_cascade_to_sub_groups = admin
+
+
+## Search Settings
+
+ckan.site_id = default
+solr_url = http://solr:8983/solr/ckan
+
+
+## Redis Settings
+
+# URL to your Redis instance, including the database to be used.
+ckan.redis.url = redis://redis:6379/1
+
+
+## CORS Settings
+
+# If cors.origin_allow_all is true, all origins are allowed.
+# If false, the cors.origin_whitelist is used.
+# ckan.cors.origin_allow_all = true
+# cors.origin_whitelist is a space separated list of allowed domains.
+# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+
+## Plugins Settings
+
+#		Add ``resource_proxy`` to enable resorce proxying and get around the
+#		same origin policy
+ckan.plugins = stats
+
+
+# Define which views should be created by default
+# (plugins must be loaded in ckan.plugins)
+#ckan.views.default_views = image_view text_view recline_view
+
+# Customize which text formats the text_view plugin will show
+#ckan.preview.json_formats = json
+#ckan.preview.xml_formats = xml rdf rdf+xml owl+xml atom rss
+#ckan.preview.text_formats = text plain text/plain
+
+# Customize which image formats the image_view plugin will show
+#ckan.preview.image_formats = png jpeg jpg gif
+
+## Front-End Settings
+
+# Uncomment following configuration to enable using of Bootstrap 2
+#ckan.base_public_folder = public-bs2
+#ckan.base_templates_folder = templates-bs2
+
+ckan.site_title = CKAN
+ckan.site_logo = /images/ckan_logo_fullname_long.png
+ckan.site_description =
+#ckan.favicon = /base/images/ckan.ico
+#ckan.gravatar_default = identicon
+#ckan.preview.direct = png jpg gif
+#ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
+#ckan.display_timezone = Etc/UTC
+
+# package_hide_extras = for_search_index_only
+#package_edit_return_url = http://another.frontend/dataset/<NAME>
+#package_new_return_url = http://another.frontend/dataset/<NAME>
+#ckan.recaptcha.publickey =
+#ckan.recaptcha.privatekey =
+#licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
+# ckan.template_footer_end =
+
+
+## Internationalisation Settings
+ckan.locale_default = en
+ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
+#    ckan.locales_offered = {{ .Values.localesOffered }}
+ckan.locales_filtered_out =
+
+## Feeds Settings
+
+ckan.feeds.authority_name =
+ckan.feeds.date =
+ckan.feeds.author_name =
+ckan.feeds.author_link =
+
+## Storage Settings
+
+#ckan.storage_path = /var/lib/ckan
+#ckan.max_resource_size = 100
+#ckan.max_image_size = 5
+
+## xloader settings
+
+#ckanext.xloader.jobs_db.uri = postgresql://postgres:123456@jobs-db/postgres
+
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
+
+## Activity Streams Settings
+
+#ckan.activity_streams_enabled = true
+ckan.activity_list_limit = 15
+ckan.activity_streams_email_notifications = True
+#ckan.email_notifications_since = 2 days
+ckan.hide_activity_from_users = %(ckan.site_id)s
+
+
+## Email settings
+
+#email_to = errors@example.com
+#error_email_from = ckan-errors@example.com
+#smtp.server = 
+#smtp.starttls = 
+#smtp.user = 
+#smtp.password = 
+#smtp.mail_from = 
+
+smtp.test_server = localhost:6675
+smtp.mail_from = info@test.ckan.net
+
+###
+
+## datajson settings
+#ckanext.datajson.inventory_links_enabled = True
+#ckanext.datajson.url_enabled = False
+
+
+## Datagov settings
+#ckanext.geodatagov.dynamic_menu.url_default = http://www.data.gov/app/plugins/datagov-custom/wp_download_links.php
+#ckanext.geodatagov.dynamic_menu.url =
+#ckanext.geodatagov.bureau_csv.url_default = https://project-open-data.cio.gov/data/omb_bureau_codes.csv
+#ckanext.geodatagov.bureau_csv.url = https://project-open-data.cio.gov/data/omb_bureau_codes.csv
+
+## Harvest settings
+#ckan.harvest.mq.type = redis
+#ckan.harvest.mq.hostname = redis
+#ckan.harvest.mq.redis_db = 9
+
+
+
+##### Configuration options specific to testing #####
+
+
+ckan.datapusher.url = http://datapusher.ckan.org/
+ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+
+
+
+ckan.cache_validation_enabled = True
+ckan.cache_enabled = False
+ckan.tests.functional.test_cache.expires = 1800
+ckan.tests.functional.test_cache.TestCacheBasics.test_get_cache_expires.expires = 3600
+
+
+package_form = standard
+licenses_group_url =
+# pyamqplib or queue
+carrot_messaging_library = queue
+
+package_new_return_url = http://localhost/dataset/<NAME>?test=new
+package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
+ckan.extra_resource_fields = alt_url
+
+# we need legacy templates for many tests to pass
+ckan.legacy_templates = yes
+
+# Add additional test specific configuration options as necessary.
+auth.blacklist = 83.222.23.234
+
+search_backend = sql
+
+# Change API key HTTP header to something non-standard.
+apikey_header_name = X-Non-Standard-CKAN-API-Key
+
+
+# use <strong> so we can check that html is *not* escaped
+ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">
+
+# use <strong> so we can check that html is *not* escaped
+ckan.template_footer_end = <strong>TEST TEMPLATE_FOOTER_END TEST</strong>
+
+
+
+ckanext.stats.cache_enabled = 0
+
+ckan.datasets_per_page = 20
+
+
+ckan.tracking_enabled = true
+
+##### End of configuration options specific to testing #####
+
+
+## Logging configuration
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+
+[logger_ckan]
+level = INFO
+handlers =
+qualname = ckan
+
+
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARNING
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARNING" logs neither.
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
The instructions in [Back-end tests](https://docs.ckan.org/en/2.8/contributing/test.html#back-end-tests) for running unit tests do not work once the datastore-db is in a different container from ckan.

Somewhat related to [PM-datagov Issue #5](https://github.com/ViderumGlobal/PM-datagov/issues/5) because of the need to be able to run unit tests.
