### PR TITLE
CCD Windows Vital Strategies

### DIFF
--- a/.docker-compose.vital-strategies-theme.yaml
+++ b/.docker-compose.vital-strategies-theme.yaml
@@ -27,8 +27,6 @@ services:
         POST_INSTALL: |
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool -b v1.5 &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview && \
-          install_standard_ckan_extension_github -r okfn/ckanext-sentry && \
-          install_standard_ckan_extension_github -r datopian/ckanext-s3filestore -b fix-null-content-type && \
           cd ~/venv/src/ckanext-querytool && ~/venv/bin/python setup.py compile_catalog -l en -f && \
           cd ~/venv/src/ckanext-querytool && ~/venv/bin/python setup.py compile_catalog -l es -f && \
           cd ~/venv/src/ckanext-querytool && ~/venv/bin/python setup.py compile_catalog -l fr -f && \
@@ -44,7 +42,6 @@ services:
       args:
         CKAN_BRANCH: ckan-2.7.3
         POST_INSTALL: |
-          install_standard_ckan_extension_github -r keitaroinc/ckanext-s3filestore &&\
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview
     environment:

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,7 +10,7 @@ ENV PIP_INDEX_URL=$PIP_INDEX_URL
 RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list \
     && apt-get -q -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade \
-    && apt-get -q -y install \
+    && apt-get -q -y --force-yes install \
         python-dev \
         python-pip \
         python-virtualenv \
@@ -58,7 +58,7 @@ USER ckan
 ARG CKAN_BRANCH
 ARG CKAN_REPO
 
-RUN CKAN_BRANCH="${CKAN_BRANCH:-ckan-2.8.1}" && CKAN_REPO="${CKAN_REPO:-ckan/ckan}" &&\
+RUN CKAN_BRANCH="${CKAN_BRANCH:-ckan-2.7.3}" && CKAN_REPO="${CKAN_REPO:-ckan/ckan}" &&\
     mkdir -p $CKAN_VENV/src &&\
     wget --no-verbose -O $CKAN_VENV/src/${CKAN_BRANCH}.tar.gz https://github.com/${CKAN_REPO}/archive/${CKAN_BRANCH}.tar.gz &&\
     cd $CKAN_VENV/src && tar -xzf ${CKAN_BRANCH}.tar.gz && mv ckan-${CKAN_BRANCH} ckan &&\

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,8 @@ services:
     build:
       context: nginx
     restart: always
+    ports:
+    - "8080:8080"
     expose:
     - "8080"
     networks:
@@ -98,7 +100,7 @@ services:
     build:
       context: ckan
       args:
-        CKAN_BRANCH: ${CKAN_BRANCH:-ckan-2.8.1}
+        CKAN_BRANCH: ${CKAN_BRANCH:-ckan-2.7.3}
         CKAN_REPO: ${CKAN_REPO:-ckan/ckan}
     restart: always
     volumes:

--- a/docker-compose/ckan-conf-templates/vital-strategies-theme-production.ini.template
+++ b/docker-compose/ckan-conf-templates/vital-strategies-theme-production.ini.template
@@ -88,8 +88,6 @@ ckan.plugins = image_view
    geojson_view
    querytool
    stats
-   sentry
-   s3filestore
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
@@ -133,19 +131,6 @@ ckan.max_image_size = 5
 
 ## Datapusher URL
 ckan.datapusher.url = {{CKAN_DATAPUSHER_URL}}
-
-## AWS S3 settings
-
-# ckanext.cloudstorage.driver = S3_US_EAST2
-# ckanext.cloudstorage.container_name = vital-strategies
-# ckanext.cloudstorage.driver_options = {"key": "{{AWS_ACCESS_KEY_ID}}", "secret": "{{AWS_SECRET_ACCESS_KEY}}"}
-ckanext.s3filestore.host_name = https://vital-strategies-ckan.s3.us-east-2.amazonaws.com
-ckanext.s3filestore.aws_storage_path = demo
-ckanext.s3filestore.aws_access_key_id = {{AWS_ACCESS_KEY_ID}}
-ckanext.s3filestore.aws_secret_access_key = {{AWS_SECRET_ACCESS_KEY}}
-ckanext.s3filestore.region_name = us-east-2
-ckanext.s3filestore.aws_bucket_name = vital-strategies-ckan
-ckanext.s3filestore.signature_version = s3v4
 
 ## Query Tool Settings
 
@@ -201,12 +186,6 @@ ckanext.datajson.url_enabled = False
 ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.redis_db = 9
-
-## Sentry settings
-sentry_dsn = {{SENTRY_DSN}}
-ckan.sentry.configure_logging = True
-ckan.sentry.log_level = ERROR
-
 
 ## Logging configuration
 [loggers]


### PR DESCRIPTION
This branch is created for the installation of CCD with Vital Strategies extension on Windows Server 2008 R2 SP1.
S3 and Sentry extensions are removed.
CKAN branch is changed to 2.7.3
Nginx port forwarding added for the port 8080.