### PR TITLE
Fixes the typo while installing CKAN

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -189,7 +189,7 @@ sudo apt install docker-compose
 
 1. Clone repository from https://github.com/datopian/ckan-cloud-docker
 ```
-git clone -b cd-windows-philippines https://github.com/datopian/ckan-cloud-docker
+git clone -b ccd-windows-philippines https://github.com/datopian/ckan-cloud-docker
 ```
 
 2. Change directory to `/ckan-cloud-docker` to enter the cloned folder.


### PR DESCRIPTION
Related issue: https://gitlab.com/datopian/core/support/-/issues/266

Changes `cd-windows-philippines` to `ccd-windows-philippines`