### PR TITLE
Use newer version of debian (jessie -> buster)

### DIFF
--- a/.docker-compose.vital-strategies-philippines-theme.yaml
+++ b/.docker-compose.vital-strategies-philippines-theme.yaml
@@ -24,6 +24,7 @@ services:
         CKAN_BRANCH: ckan-2.7.3
         EXTRA_PACKAGES: cron
         EXTRA_FILESYSTEM: "./overrides/vital-strategies/filesystem/"
+        PRE_INSTALL: "sed  -i -e 's/psycopg2==2.4.5/psycopg2==2.7.7/g' ~/venv/src/ckan/requirements.txt"
         POST_INSTALL: |
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool -b fix/geojson-ssl-error &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview && \

--- a/.docker-compose.vital-strategies-shandong-theme.yaml
+++ b/.docker-compose.vital-strategies-shandong-theme.yaml
@@ -26,6 +26,7 @@ services:
         GITHUB_URL: https://github.com.cnpmjs.org
         CKAN_BRANCH: ckan-2.7.3
         EXTRA_FILESYSTEM: "./overrides/vital-strategies/filesystem/"
+        PRE_INSTALL: "sed  -i -e 's/psycopg2==2.4.5/psycopg2==2.7.7/g' ~/venv/src/ckan/requirements.txt"
         POST_INSTALL: |
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool -b v1.8.2.1 &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview && \

--- a/.docker-compose.vital-strategies-shanghai-theme.yaml.disabled
+++ b/.docker-compose.vital-strategies-shanghai-theme.yaml.disabled
@@ -25,6 +25,7 @@ services:
         # PIP_INDEX_URL: https://pypi.tuna.tsinghua.edu.cn/simple
         CKAN_BRANCH: ckan-2.7.3
         EXTRA_FILESYSTEM: "./overrides/vital-strategies/filesystem/"
+        PRE_INSTALL: "sed  -i -e 's/psycopg2==2.4.5/psycopg2==2.7.7/g' ~/venv/src/ckan/requirements.txt"
         POST_INSTALL: |
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool -b v1.2a75 &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview && \

--- a/.docker-compose.vital-strategies-theme.yaml
+++ b/.docker-compose.vital-strategies-theme.yaml
@@ -24,6 +24,7 @@ services:
         CKAN_BRANCH: ckan-2.7.3
         EXTRA_PACKAGES: cron
         EXTRA_FILESYSTEM: "./overrides/vital-strategies/filesystem/"
+        PRE_INSTALL: "sed  -i -e 's/psycopg2==2.4.5/psycopg2==2.7.7/g' ~/venv/src/ckan/requirements.txt"
         POST_INSTALL: |
           install_standard_ckan_extension_github -r ViderumGlobal/ckanext-querytool -b fix/geojson-ssl-error &&\
           install_standard_ckan_extension_github -r ckan/ckanext-geoview && \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,6 +1,5 @@
 # Based on CKAN 2.8 Dockerfile with minor modifications for deployment on multi-tenant CKAN cluster
-
-FROM debian:jessie
+FROM debian:buster
 
 ARG EXTRA_PACKAGES
 ARG PIP_INDEX_URL
@@ -9,8 +8,7 @@ ARG GITHUB_URL
 ENV GITHUB_URL=$GITHUB_URL
 
 # Install required system packages
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list \
-    && apt-get -q -y --force-yes update \
+RUN apt-get -q -y --force-yes update \
     && DEBIAN_FRONTEND=noninteractive apt-get -q -y --force-yes upgrade \
     && apt-get -q -y --force-yes install \
         python-dev \
@@ -67,6 +65,9 @@ RUN CKAN_BRANCH="${CKAN_BRANCH:-ckan-2.8.1}" && CKAN_REPO="${CKAN_REPO:-ckan/cka
     wget --no-verbose -O $CKAN_VENV/src/${CKAN_BRANCH}.tar.gz https://github.com/${CKAN_REPO}/archive/${CKAN_BRANCH}.tar.gz &&\
     cd $CKAN_VENV/src && tar -xzf ${CKAN_BRANCH}.tar.gz && mv ckan-${CKAN_BRANCH} ckan &&\
     rm $CKAN_VENV/src/${CKAN_BRANCH}.tar.gz
+
+ARG PRE_INSTALL
+RUN eval "${PRE_INSTALL}"
 
 RUN touch $CKAN_VENV/src/ckan/requirement-setuptools.txt && ckan-pip install --index-url ${PIP_INDEX_URL:-https://pypi.org/simple/} --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirement-setuptools.txt
 RUN touch $CKAN_VENV/src/ckan/requirements.txt && ckan-pip install --index-url ${PIP_INDEX_URL:-https://pypi.org/simple/} --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirements.txt


### PR DESCRIPTION
@mpolidori Few things to note

- Uses newer version of debian - meaning we get also some security updates
  - jessie is not maintained since 2020. So it was time anyway 
- DockerFilenow allows PRE_INSTALL arg
- This PR includes fix for ALL vs deployments
  - Had to bump psycopg version to 2.7 cause of https://serverfault.com/a/1063623

Also aside not. ckan-2.7.12 is available already while we are still using 2.7.3. I did not want to include that upgrade in this PR..  But worth to upgrade I think