### PR TITLE
[solr][xs]: use 6.6.6 with the fix to deal with log4js vulnerability

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6.5
+FROM solr:6.6.6
 
 # Enviroment
 ENV SOLR_CORE ckan


### PR DESCRIPTION
SOLR has release new 6.6.6 image 2 days ago to handle log4j vulnerability. This should be applied to all instances running with docker-compose setup.

You can confirm fix is in the place by,

1. ssh into solr container `make shell C=sh S=solr O=<<Instance-id>>`
2. run `ps -ax`
3. You should get something similar

```
ps -ax
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /usr/bin/tini -- solr -f -Dlog4j2.formatMsgNoLookups=true
   12 ?        Sl     0:06 /usr/local/openjdk-8/bin/java -server ....
  135 pts/0    Ss     0:00 sh
  142 pts/0    R+     0:00 ps -ax
```


The most important part is `/usr/bin/tini -- solr -f -Dlog4j2.formatMsgNoLookups=true`. You should be able to see that if the fix is applied 